### PR TITLE
Fixing bug in Unpad method and adding unit tests.

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -18,8 +18,6 @@ func Unpad(padded []byte, size int) ([]byte, error) {
 		return nil, errors.New("Padded value wasn't in correct size.")
 	}
 
-	bufLen := size - int(padded[len(padded) - 1])
-	buf := make([]byte, bufLen)
-	copy(buf, padded[:bufLen])
-	return buf, nil
+	bufLen := len(padded) - int(padded[len(padded) - 1])
+	return padded[:bufLen], nil
 }

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -1,0 +1,83 @@
+package pkcs7_test
+
+import (
+	"testing"
+
+	"github.com/bernardigiri/go-pkcs7"
+	"github.com/stretchr/testify/assert"
+)
+
+const smallest = 16
+const largest = 256
+const stepSize = 2
+
+func TestPad(t *testing.T) {
+	testData := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for size := smallest; size<=largest; size*=stepSize {
+		for dataLen:=len(testData)-1; dataLen>=0; dataLen-- {
+			data := testData[:dataLen]
+			results, err := pkcs7.Pad(data, size)
+			assert.Nil(t, err)
+			assert.Equal(t, len(results)%size, 0)
+		}
+	}
+}
+
+
+func TestPadUnpad(t *testing.T) {
+	testData := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for size := smallest; size<largest; size*=stepSize {
+		for dataLen:=len(testData)-1; dataLen>=0; dataLen-- {
+			expected := testData[:dataLen]
+			padded, err := pkcs7.Pad(expected, size)
+			assert.Nil(t, err)
+			actual, err := pkcs7.Unpad(padded, size)
+			assert.Nil(t, err)
+			assert.Equal(t, expected, actual)
+		}
+	}
+}
+
+func TestUnpad16(t *testing.T) {
+	data := []byte{
+		0x2A,0x2A,0x2A,0x2A,
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x3,0x3,0x3,
+	}
+	expected := []byte{
+		0x2A,0x2A,0x2A,0x2A,
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,
+	}
+	actual, err := pkcs7.Unpad(data, 16)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+} 
+
+func TestUnpad32(t *testing.T) {
+	data := []byte{
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x3,0x3,0x3,
+	}
+	expected := []byte{
+		0x2A,0x2A,0x2A,0x2A,
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,0x2A,0x2A,0x2A, 
+		0x2A,
+	}
+	actual, err := pkcs7.Unpad(data, 32)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+} 


### PR DESCRIPTION
Your updated Unpad method was still using the block size to compute the buffer size, I fixed that logic and added some unit tests.